### PR TITLE
Correção de travamento ao abrir aba "Application" do dev tools de navegadores baseados em Chromium

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -27,7 +27,8 @@
   ],
   "icons": [
     {
-      "src": "/favicon.svg"
+      "src": "/favicon.svg",
+      "sizes": "16x16"
     },
     {
       "src": "icons/windows11/SmallTile.scale-100.png",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,7 +10,6 @@
   "dir": "ltr",
   "display": "standalone",
   "name": "Hinários App",
-  "orientation": "portrait-primary",
   "scope": "/",
   "short_name": "Hinários App",
   "start_url": "/",


### PR DESCRIPTION
## Outras mudanças

- https://github.com/coisasdoalto/hinarios-web/pull/32/commits/13d7ea179420b9b9f969a67c1e35bd2faad20966 Foi removido o campo `orientation` do manifesto para tentar evitar a rotação em dispositivos móveis mesmo quando bloqueado pelo sistema