### PR TITLE
Change the Android beta tester CTA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ cert.json
 **/public/sw.js.map
 **/public/worker-*.js
 **/public/worker-*.js.map
+supabase/.temp/

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -6,10 +6,12 @@ import {
   Container,
   Group,
   Header,
+  Loader,
   AppShell as MantineAppShell,
   MediaQuery,
   Navbar,
   Notification,
+  Text,
   TextInput,
   Textarea,
   useMantineTheme,
@@ -22,10 +24,10 @@ import { useHymnBooks } from '../../context/HymnBooks';
 import LoginMenu from '../LoginMenu';
 import Search from '../Search/Search';
 import VerticalNavigation from '../VerticalNavigation/VerticalNavigation';
-import { BetaTesterInviteModal, useBetaTesterInviteModal } from 'components/BetaTesterInviteModal';
 import { useFeatureFlagEnabled } from 'posthog-js/react';
-import { IconInfoCircle } from '@tabler/icons';
-import { IconInfoCircleFilled, IconInfoSmall } from '@tabler/icons-react';
+import { IconInfoSmall } from '@tabler/icons-react';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from 'supabase';
 
 export default function AppShell({ children }: PropsWithChildren) {
   const theme = useMantineTheme();
@@ -46,7 +48,12 @@ export default function AppShell({ children }: PropsWithChildren) {
     setFeedbackEnabled(false);
   }, []);
 
-  const { showBetaTesterInviteModal, controls } = useBetaTesterInviteModal();
+  const { data, isLoading } = useQuery({
+    queryKey: ['betaTestersCount'],
+    queryFn: async () => await supabase.from('beta_testers_count').select().maybeSingle(),
+  });
+
+  const betaTestersCount = data?.data?.beta_testers_count || 'algumas';
 
   return (
     <MantineAppShell
@@ -147,16 +154,24 @@ export default function AppShell({ children }: PropsWithChildren) {
 
       {shouldUseBetaTesterInviteModal && (
         <Container size="xs" mt="xl">
-          <Notification
-            title="hinarios.app na Play Store!"
-            disallowClose
-            icon={<IconInfoSmall size={36} />}
-          >
-            Ajude-nos a publicar este site na loja de aplicativos do Android,{' '}
-            <Anchor onClick={showBetaTesterInviteModal}>clique para saber mais</Anchor>.
-          </Notification>
+          <Notification disallowClose icon={<IconInfoSmall size={36} />}>
+            <Text mb={10}>
+              Já temos {isLoading ? <Loader color="blue" size="xs" /> : betaTestersCount} pessoas
+              testando o app Android! Precisamos de 20 no total para podermos publicar o app a todos
+              na Play Store.
+            </Text>
 
-          <BetaTesterInviteModal controls={controls} />
+            <Text>
+              Para se inscrever, ou se você já se inscreveu e não recebeu o link para instalação,
+              fale com o Pablo no whatsapp:{' '}
+              <Anchor
+                href="https://wa.me/5511977258561/?text=Ol%C3%A1%2C%20quero%20testar%20o%20hinarios.app%20no%20Android%0A"
+                target="_blank"
+              >
+                11 97725-8561
+              </Anchor>
+            </Text>
+          </Notification>
         </Container>
       )}
     </MantineAppShell>

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -28,6 +28,7 @@ import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { IconInfoSmall } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from 'supabase';
+import { BetaTesterInviteModal, useBetaTesterInviteModal } from 'components/BetaTesterInviteModal';
 
 export default function AppShell({ children }: PropsWithChildren) {
   const theme = useMantineTheme();
@@ -54,6 +55,8 @@ export default function AppShell({ children }: PropsWithChildren) {
   });
 
   const betaTestersCount = data?.data?.beta_testers_count || 'algumas';
+
+  const { showBetaTesterInviteModal, controls } = useBetaTesterInviteModal();
 
   return (
     <MantineAppShell
@@ -169,9 +172,12 @@ export default function AppShell({ children }: PropsWithChildren) {
                 target="_blank"
               >
                 11 97725-8561
-              </Anchor>
+              </Anchor>{' '}
+              ou adicione o seu e-mail <Anchor onClick={showBetaTesterInviteModal}>aqui</Anchor>.
             </Text>
           </Notification>
+
+          <BetaTesterInviteModal controls={controls} />
         </Container>
       )}
     </MantineAppShell>

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -1,40 +1,150 @@
-/**
- * Automatically generated from Supabase CLI with:
- * npx supabase gen types typescript --project-id xxx > supabase/database.types.ts
- */
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
 export type Database = {
   public: {
     Tables: {
       beta_testers: {
         Row: {
-          created_at: string;
-          email: string;
-          id: number;
-        };
+          created_at: string
+          email: string
+          email_sent: boolean | null
+          id: number
+          included_in_email_list: boolean | null
+        }
         Insert: {
-          created_at?: string;
-          email: string;
-          id?: number;
-        };
+          created_at?: string
+          email: string
+          email_sent?: boolean | null
+          id?: number
+          included_in_email_list?: boolean | null
+        }
         Update: {
-          created_at?: string;
-          email?: string;
-          id?: number;
-        };
-        Relationships: [];
-      };
-    };
+          created_at?: string
+          email?: string
+          email_sent?: boolean | null
+          id?: number
+          included_in_email_list?: boolean | null
+        }
+        Relationships: []
+      }
+      beta_testers_count: {
+        Row: {
+          beta_testers_count: number | null
+          created_at: string
+          id: number
+        }
+        Insert: {
+          beta_testers_count?: number | null
+          created_at?: string
+          id?: number
+        }
+        Update: {
+          beta_testers_count?: number | null
+          created_at?: string
+          id?: number
+        }
+        Relationships: []
+      }
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Enums: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
-};
+      [_ in never]: never
+    }
+  }
+}
+
+type PublicSchema = Database[Extract<keyof Database, "public">]
+
+export type Tables<
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  PublicEnumNameOrOptions extends
+    | keyof PublicSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never


### PR DESCRIPTION
Mudei a chamada para participar do closed testing do app android para mostrar a quantidade de usuários que já estão testando (valor que podemos atualizar no supabase). Creio que isso possa incentivar mais pessoas a participarem também.

Também mudei para que invés de abrir o dialog para inserir o e-mail, abra o whatsapp para enviar mensagem para mim. O dialog é legal mas acredito que essa comunicação mais direta facilite, por exemplo quando a pessoa não conseguiu instalar o app. Por outro lado estou pensando em manter o dialog e permitir que a pessoa ou envie msg pelo whats ou só insira o e-mail mesmo.