### PR TITLE
Sistema de variações de hinos

### DIFF
--- a/components/AddBreakLine/index.tsx
+++ b/components/AddBreakLine/index.tsx
@@ -1,0 +1,22 @@
+import { Fragment } from 'react';
+
+export function AddBreakLine({ children }: { children: string }) {
+  const lines = children.split('\n');
+
+  return (
+    <>
+      {lines.map((line, index) => {
+        if (index + 1 === lines.length) {
+          return <Fragment key={index}>{line}</Fragment>;
+        }
+
+        return (
+          <Fragment key={index}>
+            {line}
+            <br />
+          </Fragment>
+        );
+      })}
+    </>
+  );
+}

--- a/components/HymnTextWithVariations/index.tsx
+++ b/components/HymnTextWithVariations/index.tsx
@@ -31,7 +31,7 @@ function Variation({ options }: { options: string[] }) {
   // TODO: Save preferences
 
   const [selection, setSelection] = useState(options[0]);
-  const [opened, { close, open, toggle }] = useDisclosure(false);
+  const [opened, { close, toggle }] = useDisclosure(false);
 
   function handleSelect(option: string) {
     setSelection(option);

--- a/components/HymnTextWithVariations/index.tsx
+++ b/components/HymnTextWithVariations/index.tsx
@@ -1,0 +1,73 @@
+import { Button, Group, Popover, Text } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { AddBreakLine } from 'components/AddBreakLine';
+import { useState } from 'react';
+
+function splitTextParts(text: string) {
+  /**
+   * Example {variation1|variation2}
+   *          ^-------Match-------^
+   */
+  const regex = /\{([^}]+)\}/g;
+
+  return text.split(regex).reduce((parts, part, index) => {
+    /**
+     * Matches always come in even indices
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split#splitting_with_a_regexp_to_include_parts_of_the_separator_in_the_result
+     */
+    if (index % 2 === 0) {
+      parts.push(<AddBreakLine key={index}>{part}</AddBreakLine>);
+
+      return parts;
+    }
+    const options = part.split('|');
+    parts.push(<Variation key={index} options={options} />);
+
+    return parts;
+  }, [] as JSX.Element[]);
+}
+
+function Variation({ options }: { options: string[] }) {
+  // TODO: Save preferences
+
+  const [selection, setSelection] = useState(options[0]);
+  const [opened, { close, open, toggle }] = useDisclosure(false);
+
+  function handleSelect(option: string) {
+    setSelection(option);
+    close();
+  }
+
+  return (
+    <Popover position="bottom" withArrow shadow="md" opened={opened} onChange={toggle}>
+      <Popover.Target>
+        <Text
+          role="button"
+          display="inline"
+          onClick={toggle}
+          sx={{
+            textDecorationStyle: 'dotted',
+            cursor: 'pointer',
+          }}
+          title="Ver variações"
+          underline
+        >
+          {selection}
+        </Text>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <Group position="center">
+          {options.map((option, index) => (
+            <Button key={index} onClick={() => handleSelect(option)} variant="subtle" compact>
+              {option}
+            </Button>
+          ))}
+        </Group>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}
+
+export function HymnTextWithVariations({ children: text }: { children: string }) {
+  return <>{splitTextParts(text)}</>;
+}

--- a/pages/[hymnBook]/[slug].tsx
+++ b/pages/[hymnBook]/[slug].tsx
@@ -15,7 +15,7 @@ import { Fragment, useEffect, useState } from 'react';
 
 import { z } from 'zod';
 
-import { AddBreakLine } from 'components/AddBreakLine';
+import { HymnTextWithVariations } from 'components/HymnTextWithVariations';
 import BackButton from '../../components/BackButton/BackButton';
 import { BookmarkButton } from '../../components/BookmarkButton';
 import { useHymnBooks, useHymnBooksSave } from '../../context/HymnBooks';
@@ -52,7 +52,7 @@ export default function HymnView(props: AppProps & PageProps) {
 
   const chorusComponent = chorus && (
     <Text size={fontSize} mt={16} pl={40} italic>
-      <AddBreakLine>{chorus}</AddBreakLine>
+      <HymnTextWithVariations>{chorus}</HymnTextWithVariations>
     </Text>
   );
 
@@ -103,7 +103,7 @@ export default function HymnView(props: AppProps & PageProps) {
           {/* <Text>{stanza.number}.</Text> */}
           <Text size={fontSize} mt={16} pl={20} style={{ position: 'relative' }}>
             <span style={{ position: 'absolute', left: 0 }}>{stanza.number}.</span>
-            <AddBreakLine>{stanza.text}</AddBreakLine>
+            <HymnTextWithVariations>{stanza.text}</HymnTextWithVariations>
           </Text>
 
           {index === 0 && chorus && chorusComponent}

--- a/pages/[hymnBook]/[slug].tsx
+++ b/pages/[hymnBook]/[slug].tsx
@@ -15,6 +15,7 @@ import { Fragment, useEffect, useState } from 'react';
 
 import { z } from 'zod';
 
+import { AddBreakLine } from 'components/AddBreakLine';
 import BackButton from '../../components/BackButton/BackButton';
 import { BookmarkButton } from '../../components/BookmarkButton';
 import { useHymnBooks, useHymnBooksSave } from '../../context/HymnBooks';
@@ -23,17 +24,6 @@ import getHymnsIndex from '../../data/getHymnsIndex';
 import getParsedData from '../../data/getParsedData';
 import { Hymn, hymnSchema } from '../../schemas/hymn';
 import { HymnBook } from '../../schemas/hymnBook';
-
-const AddBreakLine = ({ children }: { children: string }) => (
-  <>
-    {children.split('\n').map((line, index) => (
-      <Fragment key={index}>
-        {line}
-        <br />
-      </Fragment>
-    ))}
-  </>
-);
 
 const validateFontSize = (fontSize: string): fontSize is MantineSize => /md|lg|xl/.test(fontSize);
 


### PR DESCRIPTION
É de nosso conhecimento que alguns hinos tem variações, sejam elas por costume de alguma edição mais antiga ou alguma correção de palavara que reflete melhor a ideia do hino. Pensando nisso criamos um sistema para suportar essas variações.

# Como funciona

As variações serão criadas dentro do texto dos hinos nesse padrão: `{variação1|variação2}`
![image](https://github.com/user-attachments/assets/ccc96c12-5d5b-4719-89fc-bcc8b76583c1)
> Exemplo

A renderização do texto dos hinos foi ajustada para utilizar um novo componente (`HymnTextWithVariations`). Esse componente verifica o texto e substitue as ocorrências do padrão de variações no texto por um componente customizado que permite ver as variações e trocar por uma delas.

# Demonstração

https://github.com/user-attachments/assets/6c66885f-447f-4f2e-a77c-efd3feaa5e2d

