### PR TITLE
Identificando usuário no Posthog

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -18,6 +18,16 @@ if (typeof window !== 'undefined') {
     capture_pageview: process.env.NODE_ENV === 'production',
     capture_performance: process.env.NODE_ENV === 'production',
     capture_pageleave: process.env.NODE_ENV === 'production',
+    bootstrap: {
+      featureFlags: {
+        login: false,
+        bookmarks: false,
+      },
+    },
+  });
+
+  posthog.setPersonPropertiesForFlags({
+    environment: process.env.NODE_ENV,
   });
 }
 


### PR DESCRIPTION
Inclui uma mudança que identifica o usuário com uid e e-mail nos eventos do Posthog. Também inclui o `NODE_ENV` como propriedade no contexto das flags pra conseguir habilitar flags localmente mais facilmente. E por último, inclui a propriedade `bootstrap.featureFlags` na inicialização do Posthog, conforme recomendado em: https://posthog.com/product-engineers/feature-flag-best-practices#5-bootstrap-your-flags-to-make-them-available-immediately
